### PR TITLE
added license manifest parsing script

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -69,6 +69,13 @@ task :cytovale_release => [:cytovale_image] do
   build_info_directory = File.join(release_directory, "build_info")
   write_host_info(build_info_directory)
   write_docker_image_info(build_info_directory)
+  
+  # Copy and parse the licenses manifest
+  licenses_manifest = File.join(PROJECT_ROOT, "deploy", "licenses", "apalis_imx6", "Apalis-iMX6_LXDE-Image", "license.manifest")
+  licenses_list  = File.join(build_info_directory, "licenses.txt")
+  license_parsing_script = File.join(PROJECT_ROOT, "scripts", "license_manifest_parser.py")
+  FileUtils.cp(licenses_manifest, build_info_directory)
+  `python3 "#{license_parsing_script}" "#{licenses_manifest}" "#{licenses_list}"`
 
   # Get our Linux binaries
   linux_directory =  File.join(release_directory, "linux")
@@ -85,6 +92,8 @@ task :cytovale_release => [:cytovale_image] do
   rootfs_manifest = File.join(deploy_dir, "LXDE-Image-apalis-imx6.manifest")
   FileUtils.cp(rootfs_tarball, rootfs_directory)
   FileUtils.cp(rootfs_manifest, rootfs_directory)
+
+
 
   # Create the install package zip file by running the update.sh script
   release_tag = "Apalis-iMX6_LXDE-Image_2.8"

--- a/scripts/license_manifest_parser.py
+++ b/scripts/license_manifest_parser.py
@@ -1,0 +1,41 @@
+import re
+import sys
+
+
+def get_license_names(file_location):
+    """
+    Returns a list of all unique licenses used in the manifest file
+    Expects the format
+    "
+    LICENSE: GPLv2+ & LGPLv2.1+
+    "
+    :param file_location:
+    :return:
+    """
+    retval = []
+    with open(file_location, 'r') as fpt:
+        for line in fpt.readlines():
+            if line.startswith("LICENSE: "):
+                # strip off "LICENSE: "
+                l = line[9:]
+                licenses = re.split(" [|&] ", l)
+                for l in licenses:
+                    l = l.strip(" \n()")
+                    if l not in retval:
+                        retval.append(l)
+    return retval
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 3:
+        print("Usage: {} INPUT_FILE OUTPUT_FILE".format(sys.argv[0]))
+        sys.exit(1)
+    input = sys.argv[1]
+    output = sys.argv[2]
+
+    with open(output, 'w') as fpt:
+        for license in get_license_names(input):
+            fpt.write(license + "\n")
+
+


### PR DESCRIPTION
License info is now stored in the "build_info" directory when building a release image